### PR TITLE
CAL-33: Use maven-bnd-plugin to automate OSGi manifest generation

### DIFF
--- a/cal10n-api/pom.xml
+++ b/cal10n-api/pom.xml
@@ -11,7 +11,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>cal10n-api</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <name>Compiler assisted localization library (CAL10N) -    API</name>
 
   <dependencies>
@@ -20,24 +20,24 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_include>-target/classes/META-INF/${project.artifactId}.bnd</_include>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Bundle-Version>${project.version}</Bundle-Version>
-              <Bundle-Description>${project.description}</Bundle-Description>
-              <Implementation-Version>${project.version}</Implementation-Version>
-            </manifestEntries>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-          </archive>
-        </configuration>
         <executions>
           <execution>
             <id>bundle-test-jar</id>
             <phase>package</phase>
             <goals>
-              <goal>jar</goal>
               <goal>test-jar</goal>
             </goals>
           </execution>

--- a/cal10n-api/src/main/resources/META-INF/MANIFEST.MF
+++ b/cal10n-api/src/main/resources/META-INF/MANIFEST.MF
@@ -1,7 +1,0 @@
-Implementation-Title: cal10n-api
-Bundle-ManifestVersion: 2
-Bundle-SymbolicName: cal10n.api
-Bundle-Name: cal10n-api
-Bundle-Vendor: qos.ch
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
-Export-Package: ch.qos.cal10n;version=${project.version}, ch.qos.cal10n.util;version=${project.version}

--- a/cal10n-api/src/main/resources/META-INF/cal10n-api.bnd
+++ b/cal10n-api/src/main/resources/META-INF/cal10n-api.bnd
@@ -1,0 +1,26 @@
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS  IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+# Retro-compatible with previous manifest (try defaults from bnd)
+Bundle-SymbolicName: cal10n.api
+Bundle-Name: cal10n-api
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+
+# bnd exports all packages not matching *.impl and *.internal by default


### PR DESCRIPTION
Hi,

kindly find a commit integrating maven-bnd-plugin in your build to allow automatic generation of the bundle manifest for the cal10n-api module.

Thanks & regards,
Loïc
