### PR TITLE
MessageKeyVerifier: Use correct locale to get charset

### DIFF
--- a/cal10n-api/src/main/java/ch/qos/cal10n/verifier/MessageKeyVerifier.java
+++ b/cal10n-api/src/main/java/ch/qos/cal10n/verifier/MessageKeyVerifier.java
@@ -86,7 +86,7 @@ public class MessageKeyVerifier implements IMessageKeyVerifier {
       return errorList;
     }
 
-    String charset = AnnotationExtractor.getCharset(enumType, Locale.FRENCH);
+    String charset = AnnotationExtractor.getCharset(enumType, locale);
     ResourceBundle rb = CAL10NResourceBundleFinder.getBundle(this.getClass()
         .getClassLoader(), baseName, locale, charset);
 


### PR DESCRIPTION
For some reason Locale.FRENCH is used instead of the method parameter "locale" when looking up the charset to use. This fixes that.
