### PR TITLE
Adding optional fallback to root language bundle

### DIFF
--- a/cal10n-api/src/main/java/ch/qos/cal10n/Settings.java
+++ b/cal10n-api/src/main/java/ch/qos/cal10n/Settings.java
@@ -1,0 +1,16 @@
+package ch.qos.cal10n;
+
+public class Settings
+{
+    private static boolean rootLanguageFallbackEnabled = false;
+    
+    public static void setRootLanguageFallbackEnabled(boolean enabled)
+    {
+        rootLanguageFallbackEnabled = enabled;
+    }
+    
+    public static boolean isRootLanguageFallbackEnabled()
+    {
+        return rootLanguageFallbackEnabled ;
+    }
+}

--- a/cal10n-api/src/main/java/ch/qos/cal10n/util/CAL10NBundle.java
+++ b/cal10n-api/src/main/java/ch/qos/cal10n/util/CAL10NBundle.java
@@ -89,12 +89,22 @@ public class CAL10NBundle extends ResourceBundle {
     nextCheck = 0;
     lastModified = 0;
   } 
+  
+  protected Map<String, String> getMap() {
+    if(parent == null) {
+      return this.map;
+    } else {
+      Hashtable<String, String> ht = new Hashtable<String, String>(map);
+      ht.putAll(parent.getMap());
+      return ht;
+    }
+  }
 
   @Override
   public Enumeration<String> getKeys() {
     Hashtable<String, String> ht = new Hashtable<String, String>(map);
     if(parent != null) {
-      ht.putAll(parent.map);
+      ht.putAll(parent.getMap());
     }
     return ht.keys();
   }

--- a/cal10n-api/src/main/java/ch/qos/cal10n/verifier/AbstractMessageKeyVerifier.java
+++ b/cal10n-api/src/main/java/ch/qos/cal10n/verifier/AbstractMessageKeyVerifier.java
@@ -1,11 +1,13 @@
 package ch.qos.cal10n.verifier;
 
+import ch.qos.cal10n.Settings;
+import ch.qos.cal10n.util.AbstractCAL10NBundleFinder;
 import ch.qos.cal10n.util.AnnotationExtractor;
 import ch.qos.cal10n.util.CAL10NBundleFinder;
 import ch.qos.cal10n.util.MiscUtil;
-
 import static ch.qos.cal10n.verifier.Cal10nError.ErrorType.MISSING_LOCALE_DATA_ANNOTATION;
 import static ch.qos.cal10n.verifier.Cal10nError.ErrorType.MISSING_BN_ANNOTATION;
+
 
 
 import java.util.*;
@@ -140,6 +142,12 @@ abstract public class AbstractMessageKeyVerifier implements IMessageKeyVerifier 
       return errorList;
     }
     for (String localeName : localeNameArray) {
+      if ("".equals(localeName)) {
+        Settings.setRootLanguageFallbackEnabled(true);
+      } else {
+        //false is the default, but we might want to 'unset' it if the previous iteration of this loop set it to true.
+        Settings.setRootLanguageFallbackEnabled(false);
+      }
       Locale locale = MiscUtil.toLocale(localeName);
       List<Cal10nError> tmpList = verify(locale);
       errorList.addAll(tmpList);


### PR DESCRIPTION
I understand the fact that CAL10n doesn’t fall back to a ‘root’ language in the same way that java resource bundles do, and I understand that this was done for reasons of ‘least surprise’. However, I’d like to add the option of a fall-back. I’d like to use CAL10n, but without this feature, using CAL10n on my project is tricky. Therefore, I have implemented a change to allow a fall-back. I have tried to ensure it has the least impact on other developers or people currently using the library. So, if it looks a bit hacky (and it probably is) it’s because I’m trying to make the least changes possible. 

Projects using CAL10n which wish to set this fall-back have to call `Settings.setRootLanguageFallbackEnabled(true);` before loading any bundles. Projects who want to use CAL10n in the traditional way need to do nothing.

The reason I would like this change is that the distribution of language packs is done totally separately to the building of my product. Therefore, at compile time there’s only likely to be one set of language files in the product (English). This means that if someone deploys the product on a system with a different locale, they need a new language pack. It would be far easier if the language files I provided were for a ‘root’ language, which could be fallen back to. This means that (for example) if a customer moved our application from a data centre in Germany to a data centre in Thailand, it doesn’t matter what the locale settings for those environments are, the application will still run and will still have logging (currently CAL10n throws an exception if the language files cannot be found, and thus there is no logging). English might be not the ideal language here, but it’s better than the app simply not running or not having any logging.
