### PR TITLE
Using cal10n-api: fix SupportedSourceVersion compilation warning

### DIFF
--- a/cal10n-api/src/main/java/ch/qos/cal10n/verifier/processor/CAL10NAnnotationProcessor.java
+++ b/cal10n-api/src/main/java/ch/qos/cal10n/verifier/processor/CAL10NAnnotationProcessor.java
@@ -13,11 +13,30 @@ import java.util.List;
 import java.util.Set;
 
 @SupportedAnnotationTypes("ch.qos.cal10n.BaseName")
-@SupportedSourceVersion(SourceVersion.RELEASE_5)
 public class CAL10NAnnotationProcessor extends AbstractProcessor {
 
   TypeElement baseNameTypeElement;
   Filer filer;
+
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+
+    //Replacement of @SupportedSourceVersion(SourceVersion.RELEASE_5) because it generate compilation warning like:
+    //[WARNING] Supported source version 'RELEASE_5' from annotation processor 'ch.qos.cal10n.verifier.processor.CAL10NAnnotationProcessor' less than -source '1.7'
+    try {
+      return SourceVersion.valueOf("RELEASE_8");
+    } catch (IllegalArgumentException e) {}
+
+    try {
+      return SourceVersion.valueOf("RELEASE_7");
+    } catch (IllegalArgumentException e) {}
+
+    try {
+      return SourceVersion.valueOf("RELEASE_6");
+    } catch (IllegalArgumentException x) {}
+
+    return SourceVersion.RELEASE_5;
+  }
 
   @Override
   public void init(ProcessingEnvironment env) {


### PR DESCRIPTION
When using cal10n-api this compilation warning is displayed:
`[WARNING] Supported source version 'RELEASE_5' from annotation processor 'ch.qos.cal10n.verifier.processor.CAL10NAnnotationProcessor' less than -source '1.7'`

This workaround has been found on netbeans and another projetct bug tracker: https://netbeans.org/bugzilla/show_bug.cgi?id=210286
https://github.com/kohsuke/metainf-services/issues/3
They have the same warning.

This warning will not be fixed in the java compiler by a -Xlint option because this behaviour is expected and documented:
https://bugs.openjdk.java.net/browse/JDK-8037955
https://bugs.openjdk.java.net/browse/JDK-7184902

