### PR TITLE
Removing need for enum attributes to be defined as keys in resource files

### DIFF
--- a/cal10n-api/src/main/java/ch/qos/cal10n/verifier/processor/MessageKeyVerifierByTypeElement.java
+++ b/cal10n-api/src/main/java/ch/qos/cal10n/verifier/processor/MessageKeyVerifierByTypeElement.java
@@ -4,6 +4,7 @@ import ch.qos.cal10n.util.CAL10NBundleFinder;
 import ch.qos.cal10n.verifier.AbstractMessageKeyVerifier;
 
 import javax.annotation.processing.Filer;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.util.ElementFilter;
@@ -31,7 +32,9 @@ public class MessageKeyVerifierByTypeElement extends AbstractMessageKeyVerifier 
   public List<String> extractKeysInEnum() {
     List<String> keyList = new ArrayList<String>();
     for (VariableElement ve : ElementFilter.fieldsIn(typeElementForEnum.getEnclosedElements())) {
-      keyList.add(ve.getSimpleName().toString());
+      if ( ve.getKind() == ElementKind.ENUM_CONSTANT) {
+        keyList.add(ve.getSimpleName().toString());
+      }
     }
     return keyList;
   }


### PR DESCRIPTION
If a localization enum contains properties (which would be required if each enum constant required a message code for example) e.g.
```
package com.c10n.messagecode;

import ch.qos.cal10n.LocaleData;
import ch.qos.cal10n.Locale;
import ch.qos.cal10n.BaseName;

@BaseName("colors")
@LocaleData( { @Locale("en"), @Locale("fr") })
public enum Colors  {

    APPLE_COLOR("APPLE_COLOR_CODE");

    String colorCode;

    Colors(String colorCode)
    {
        this.colorCode=colorCode;
    }

    public String getColorCode()
    {
        return colorCode;
    }
}
```

and a resource bundle such as colors_en.properties
```
APPLE_COLOR=Apples are {0}
```

then when trying to compile with mvn clean install, the following error occurs during compilation:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project messagecode: Compilation failure
[ERROR] src/main/java/com/c10n/messagecode/Colors.java:[9,8] Key [colorCode] present in enum type [com.c10n.messagecode.Colors] but absent in resource bundle named [colors] for locale [en]
```
colorCode is mistakenly required in the resource bundle files (e.g. colors_en.properties).  The ugly workaround is to add a line in each of the resource bundle files such as
```
colorCode=1
```

It would be much better if this ugly workaround was not required.  This PR addresses the issue by only requiring ElementKind.ENUM_CONSTANT types from an enum to be present in resource bundles.

Sample Main to exercise the above classes and resources:
```
package com.c10n.messagecode;

import java.util.Locale;

import ch.qos.cal10n.IMessageConveyor;
import ch.qos.cal10n.MessageConveyor;

public class Main {

    public static void main(String args[]) {

        IMessageConveyor mc_En_Uk = new MessageConveyor(Locale.ENGLISH);

        System.out.println(mc_En_Uk.getMessage(Colors.APPLE_COLOR, "shiney green"));
 
        System.out.println("Color code is: " + Colors.APPLE_COLOR.getColorCode());
    }
}
```

Sample pom.xml to compile all of the above code
```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>

    <groupId>com.c10n</groupId>
    <artifactId>messagecode</artifactId>
    <version>1.0-SNAPSHOT</version>

    <dependencies>
        <dependency>
            <groupId>ch.qos.cal10n</groupId>
            <artifactId>cal10n-api</artifactId>
            <version>0.8.1</version>
        </dependency>
        <dependency>
            <groupId>ch.qos.cal10n.plugins</groupId>
            <artifactId>maven-cal10n-plugin</artifactId>
            <version>0.8.1</version>
        </dependency>
    </dependencies>


</project>
```

